### PR TITLE
NGSTACK-546 add js lint action

### DIFF
--- a/src/Action/JSLinter.php
+++ b/src/Action/JSLinter.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\GitHooks\Action;
+
+use CaptainHook\App\Config;
+use CaptainHook\App\Console\IO;
+use SebastianFeldmann\Cli\Processor\ProcOpen as Processor;
+use SebastianFeldmann\Git\Repository;
+use function escapeshellarg;
+use function preg_match;
+
+final class JSLinter extends Action
+{
+    protected const ERROR_MESSAGE = 'Committed JS code did not pass linter. Please check the output for suggested diff.';
+
+    protected function doExecute(Config $config, IO $io, Repository $repository, Config\Action $action): void
+    {
+        $changedJsFiles = $repository->getIndexOperator()->getStagedFilesOfType('js');
+        if (empty($changedJsFiles)) {
+            return;
+        }
+
+        $excludedFiles = $action->getOptions()->get('excluded_files');
+
+        $linterCommand = $action->getOptions()->get('linter_command', 'yarn eslint');
+        $linterOptions = $action->getOptions()->get('linter_options', '--fix-dry-run');
+
+        $io->write('Running linter on files:', true, IO::VERBOSE);
+        foreach ($changedJsFiles as $file) {
+            if ($this->shouldSkipFileCheck($file, $excludedFiles)) {
+                continue;
+            }
+
+            $result = $this->lintFile($file, $linterCommand, $linterOptions);
+
+            $io->write($result['output'], true);
+
+            if ($result['success'] !== true) {
+                $this->throwError($action, $io);
+            }
+        }
+    }
+
+    protected function shouldSkipFileCheck(string $file, array $excludedFiles): bool
+    {
+        foreach ($excludedFiles as $excludedFile) {
+            // File definition using regexp
+            if ($excludedFile[0] === '/') {
+                if (preg_match($excludedFile, $file)) {
+                    return true;
+                }
+
+                continue;
+            }
+            if ($excludedFile === $file) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function lintFile(string $file, string $linterCommand, string $linterOptions): array
+    {
+        $process = new Processor();
+        $result = $process->run($linterCommand.' '.$linterOptions.'  '.escapeshellarg($file));
+
+        return [
+            'success' => $result->isSuccessful(),
+            'output' => $result->getStdOut(),
+        ];
+    }
+}

--- a/src/Action/JSPrettier.php
+++ b/src/Action/JSPrettier.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\GitHooks\Action;
+
+use CaptainHook\App\Config;
+use CaptainHook\App\Console\IO;
+use SebastianFeldmann\Cli\Processor\ProcOpen as Processor;
+use SebastianFeldmann\Git\Repository;
+use function escapeshellarg;
+use function preg_match;
+
+final class JSPrettier extends Action
+{
+    protected const ERROR_MESSAGE = 'Committed JS code did not pass prettier. Please run prettier on your files before committing them.';
+
+    protected function doExecute(Config $config, IO $io, Repository $repository, Config\Action $action): void
+    {
+        $changedJsFiles = $repository->getIndexOperator()->getStagedFilesOfType('js');
+        if (empty($changedJsFiles)) {
+            return;
+        }
+
+        $excludedFiles = $action->getOptions()->get('excluded_files');
+
+        $prettierCommand = $action->getOptions()->get('prettier_command', 'yarn prettier');
+        $prettierOptions = $action->getOptions()->get('prettier_options', '--check');
+
+        $io->write('Running prettier on files:', true, IO::VERBOSE);
+        foreach ($changedJsFiles as $file) {
+            if ($this->shouldSkipFileCheck($file, $excludedFiles)) {
+                continue;
+            }
+
+            $result = $this->lintFile($file, $prettierCommand, $prettierOptions);
+
+            $io->write($result['output'], true);
+
+            if ($result['success'] !== true) {
+                $this->throwError($action, $io);
+            }
+        }
+    }
+
+    protected function shouldSkipFileCheck(string $file, array $excludedFiles): bool
+    {
+        foreach ($excludedFiles as $excludedFile) {
+            // File definition using regexp
+            if ($excludedFile[0] === '/') {
+                if (preg_match($excludedFile, $file)) {
+                    return true;
+                }
+
+                continue;
+            }
+            if ($excludedFile === $file) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function lintFile(string $file, string $prettierCommand, string $prettierOptions): array
+    {
+        $process = new Processor();
+        $result = $process->run($prettierCommand.' '.$prettierOptions.'  '.escapeshellarg($file));
+
+        return [
+            'success' => $result->isSuccessful(),
+            'output' => $result->getStdOut(),
+        ];
+    }
+}


### PR DESCRIPTION
* if prettier fails, the commit will not pass, and the error message will be shown: `Committed JS code did not pass prettier. Please run prettier on your files before committing them.`
* unfotunately, prettier still does not offer diff https://github.com/prettier/prettier/issues/6885
* if eslint fails, it will provide output with found issues. example output:
```
 - \Netgen\GitHooks\Action\JSLinter                                  : yarn run v1.19.2
$ /home/user/project/node_modules/.bin/eslint --fix-dry-run src/AppBundle/Resources/es6/app.js

/home/user/project/src/AppBundle/Resources/es6/app.js
   21:7   error  'closeSideMenu' was used before it was defined  no-use-before-define
   27:7   error  'closeSideMenu' was used before it was defined  no-use-before-define
   32:5   error  'test' is not defined                           no-undef
   32:12  error  'test' is assigned to itself                    no-self-assign
   32:12  error  'test' is not defined                           no-undef
  105:16  error  'Swiper' is not defined                         no-undef
  141:16  error  'Swiper' is not defined                         no-undef

✖ 8 problems (8 errors, 0 warnings)

info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

Committed JS code did not pass linter. Please check the output for suggested diff.
failed
```

Related PR: https://github.com/netgen/media-site/pull/74