### PR TITLE
NGSTACK-789 add extensions array option

### DIFF
--- a/src/Action/Action.php
+++ b/src/Action/Action.php
@@ -18,7 +18,7 @@ abstract class Action implements ActionInterface
 {
     protected const ERROR_MESSAGE = "I'm sorry, Dave. I'm afraid I can't do that. Please check your commit for errors";
 
-    public function execute(Config $config, IO $io, Repository $repository, Config\Action $action): void
+    public function execute(Config $config, IO $io, Repository $repository, ActionConfig $action): void
     {
         if (!$this->isEnabled($action)) {
             return;
@@ -27,7 +27,7 @@ abstract class Action implements ActionInterface
         $this->doExecute($config, $io, $repository, $action);
     }
 
-    abstract protected function doExecute(Config $config, IO $io, Repository $repository, Config\Action $action): void;
+    abstract protected function doExecute(Config $config, IO $io, Repository $repository, ActionConfig $action): void;
 
     protected function throwError(ActionConfig $config, IO $io): void
     {

--- a/src/Action/JSLinter.php
+++ b/src/Action/JSLinter.php
@@ -19,8 +19,14 @@ final class JSLinter extends Action
 
     protected function doExecute(Config $config, IO $io, Repository $repository, Config\Action $action): void
     {
-        $changedJsFiles = $repository->getIndexOperator()->getStagedFilesOfType('js');
-        if (count($changedJsFiles) === 0) {
+        $extensions = $action->getOptions()->get('extensions', ['js']);
+        
+        $changedFiles = [];
+        foreach ($extensions as $extension) {
+            $changedFiles = array_merge($changedFiles, $repository->getIndexOperator()->getStagedFilesOfType($extension));
+        }
+
+        if (count($changedFiles) === 0) {
             return;
         }
 
@@ -30,7 +36,7 @@ final class JSLinter extends Action
         $linterOptions = $action->getOptions()->get('linter_options', '--fix-dry-run');
 
         $io->write('Running linter on files:', true, IO::VERBOSE);
-        foreach ($changedJsFiles as $file) {
+        foreach ($changedFiles as $file) {
             if ($this->shouldSkipFileCheck($file, $excludedFiles)) {
                 continue;
             }

--- a/src/Action/JSLinter.php
+++ b/src/Action/JSLinter.php
@@ -9,6 +9,7 @@ use CaptainHook\App\Console\IO;
 use SebastianFeldmann\Cli\Processor\ProcOpen as Processor;
 use SebastianFeldmann\Git\Repository;
 
+use function array_merge;
 use function count;
 use function escapeshellarg;
 use function preg_match;
@@ -20,7 +21,7 @@ final class JSLinter extends Action
     protected function doExecute(Config $config, IO $io, Repository $repository, Config\Action $action): void
     {
         $extensions = $action->getOptions()->get('extensions', ['js']);
-        
+
         $changedFiles = [];
         foreach ($extensions as $extension) {
             $changedFiles = array_merge($changedFiles, $repository->getIndexOperator()->getStagedFilesOfType($extension));

--- a/src/Action/JSPrettier.php
+++ b/src/Action/JSPrettier.php
@@ -9,6 +9,7 @@ use CaptainHook\App\Console\IO;
 use SebastianFeldmann\Cli\Processor\ProcOpen as Processor;
 use SebastianFeldmann\Git\Repository;
 
+use function array_merge;
 use function count;
 use function escapeshellarg;
 use function preg_match;
@@ -20,7 +21,7 @@ final class JSPrettier extends Action
     protected function doExecute(Config $config, IO $io, Repository $repository, Config\Action $action): void
     {
         $extensions = $action->getOptions()->get('extensions', ['js']);
-        
+
         $changedFiles = [];
         foreach ($extensions as $extension) {
             $changedFiles = array_merge($changedFiles, $repository->getIndexOperator()->getStagedFilesOfType($extension));

--- a/src/Action/JSPrettier.php
+++ b/src/Action/JSPrettier.php
@@ -19,8 +19,14 @@ final class JSPrettier extends Action
 
     protected function doExecute(Config $config, IO $io, Repository $repository, Config\Action $action): void
     {
-        $changedJsFiles = $repository->getIndexOperator()->getStagedFilesOfType('js');
-        if (count($changedJsFiles) === 0) {
+        $extensions = $action->getOptions()->get('extensions', ['js']);
+        
+        $changedFiles = [];
+        foreach ($extensions as $extension) {
+            $changedFiles = array_merge($changedFiles, $repository->getIndexOperator()->getStagedFilesOfType($extension));
+        }
+
+        if (count($changedFiles) === 0) {
             return;
         }
 
@@ -30,7 +36,7 @@ final class JSPrettier extends Action
         $prettierOptions = $action->getOptions()->get('prettier_options', '--check');
 
         $io->write('Running prettier on files:', true, IO::VERBOSE);
-        foreach ($changedJsFiles as $file) {
+        foreach ($changedFiles as $file) {
             if ($this->shouldSkipFileCheck($file, $excludedFiles)) {
                 continue;
             }


### PR DESCRIPTION
Instead of hardcoded single `js` extension, the action takes an `"extensions": []` option to allow for other possible JS extensions - jsx, ts, tsx. 