### PR TITLE
NGSTACK-957 read and output stderr from eslint and prettier

### DIFF
--- a/src/Action/JSLinter.php
+++ b/src/Action/JSLinter.php
@@ -44,9 +44,10 @@ final class JSLinter extends Action
 
             $result = $this->lintFile($file, $linterCommand, $linterOptions);
 
-            $io->write($result['output']);
-
-            if ($result['success'] !== true) {
+            if ($result['success'] === true) {
+                $io->write($result['output']);
+            } else {
+                $io->writeError(sprintf('<error>%s</error>', $result['error']));
                 $this->throwError($action, $io);
             }
         }
@@ -85,6 +86,7 @@ final class JSLinter extends Action
         return [
             'success' => $result->isSuccessful(),
             'output' => $result->getStdOut(),
+            'error' => $result->getStdErr(),
         ];
     }
 }

--- a/src/Action/JSLinter.php
+++ b/src/Action/JSLinter.php
@@ -13,6 +13,7 @@ use function array_merge;
 use function count;
 use function escapeshellarg;
 use function preg_match;
+use function sprintf;
 
 final class JSLinter extends Action
 {

--- a/src/Action/JSPrettier.php
+++ b/src/Action/JSPrettier.php
@@ -44,9 +44,10 @@ final class JSPrettier extends Action
 
             $result = $this->lintFile($file, $prettierCommand, $prettierOptions);
 
-            $io->write($result['output']);
-
-            if ($result['success'] !== true) {
+            if ($result['success'] === true) {
+                $io->write($result['output']);
+            } else {
+                $io->writeError(sprintf('<error>%s</error>', $result['error']));
                 $this->throwError($action, $io);
             }
         }
@@ -85,6 +86,7 @@ final class JSPrettier extends Action
         return [
             'success' => $result->isSuccessful(),
             'output' => $result->getStdOut(),
+            'error' => $result->getStdErr(),
         ];
     }
 }

--- a/src/Action/JSPrettier.php
+++ b/src/Action/JSPrettier.php
@@ -13,6 +13,7 @@ use function array_merge;
 use function count;
 use function escapeshellarg;
 use function preg_match;
+use function sprintf;
 
 final class JSPrettier extends Action
 {


### PR DESCRIPTION
Changes
---
- original eslint and prettier hooks were missing the stderr from the commands, which leads to confusion when it throws an error due to node version
- error is displayed like in https://github.com/netgen/git-hooks/pull/14/

Testing
---
- use wrong node version from the one defined in project
- add a test change to and stage a js file
- add JSLinter to pre-commit hooks
- run git commit - should see error with node version being wrong (expected version...)
- do the same with JSPrettier

minimal adding of hooks to pre-commit
```
{
    "action": "\\Netgen\\GitHooks\\Action\\JSLinter",
    "options": {
        "excluded_files": []
    }
},
{
    "action": "\\Netgen\\GitHooks\\Action\\JSPrettier",
    "options": {
        "excluded_files": []
    }
},
```